### PR TITLE
curand_Philox4x32_10 for AMD

### DIFF
--- a/src/core/curand_wrapper.hpp
+++ b/src/core/curand_wrapper.hpp
@@ -1,13 +1,31 @@
 #ifndef CURAND_WRAPPER_HPP
 #define CURAND_WRAPPER_HPP
 
-#if defined(__HIPCC__) // AMD or Nvidia via HIP
-
-#include <hiprand/hiprand_kernel.h>
-
-#else
+#if defined(__CUDACC__)
 
 #include <curand_kernel.h>
 
+#elif defined(__HIPCC__)
+
+#include <hiprand/hiprand_kernel.h>
+
+class philox4x32_10_stateless : private rocrand_device::philox4x32_10_engine {
+public:
+  FQUALIFIERS
+  philox4x32_10_stateless() {}
+
+  FQUALIFIERS
+  uint4 operator()(uint4 counter, uint2 key) {
+    return ten_rounds(counter, key);
+  }
+};
+
+__forceinline__ __device__ uint4 curand_Philox4x32_10(uint4 counter,
+                                                      uint2 key) {
+  philox4x32_10_stateless *e;
+  return (*e)(counter, key);
+}
+
 #endif
-#endif
+
+#endif // CURAND_WRAPPER_HPP

--- a/src/core/curand_wrapper.hpp
+++ b/src/core/curand_wrapper.hpp
@@ -7,7 +7,7 @@
 
 #elif defined(__HIPCC__)
 
-#include <hiprand/hiprand_kernel.h>
+#include <rocrand/rocrand_kernel.h>
 
 class philox4x32_10_stateless : private rocrand_device::philox4x32_10_engine {
 public:

--- a/src/core/curand_wrapper.hpp
+++ b/src/core/curand_wrapper.hpp
@@ -9,6 +9,8 @@
 
 #include <rocrand/rocrand_kernel.h>
 
+#define CURAND_2POW32_INV ROCRAND_2POW32_INV
+
 class philox4x32_10_stateless : private rocrand_device::philox4x32_10_engine {
 public:
   FQUALIFIERS


### PR DESCRIPTION
For https://github.com/espressomd/espresso/pull/2348

This code is hacky because AMD doesn't provide a stateless Philox outside of an engine. It is available as a `protected` but side effect-free member function of the engine though. So I wrote a class that inherits from the engine and makes that function public. To avoid the overhead of constructing member variables we don't need, I call the function on an uninitialized pointer. I know that's ugly, but it reduces the number of instructions that a single Philox call takes by 50 %.